### PR TITLE
Added a coGroup function to Pump

### DIFF
--- a/src/main/java/org/ch/pump/Pump.java
+++ b/src/main/java/org/ch/pump/Pump.java
@@ -43,6 +43,14 @@ public class Pump {
     return new Pump(pipe);
   }
 
+  public Pump cogroup(Pump other, String... cogroupFields) {
+	  return cogroup(this, other, cogroupFields);
+  }
+  
+  public Pump cogroup(Pump other, Joiner joiner, String... cogroupFields) {
+	  return cogroup(this, other, joiner, cogroupFields);
+  }
+  
   public static Pump cogroup(Pump left, Pump right, String... cogroupFields) {
     return cogroup(left, right, new InnerJoin(), cogroupFields);
   }

--- a/src/test/java/org/ch/pump/TestPump.java
+++ b/src/test/java/org/ch/pump/TestPump.java
@@ -189,7 +189,7 @@ public class TestPump extends TestCase {
     Pump right = Pump.prime("right")
         .each(new RegexSplitter(new Fields("date", "tag"),"\t"), "line");
 
-    Pipe pipe = Pump.cogroup(left, right, "date")
+    Pipe pipe = left.cogroup(right, "date")
         .retain("date", "count", "tag")
         .toPipe();
 

--- a/src/test/java/org/ch/pump/TestPump.java
+++ b/src/test/java/org/ch/pump/TestPump.java
@@ -6,6 +6,7 @@ import cascading.operation.aggregator.Count;
 import cascading.operation.regex.RegexFilter;
 import cascading.operation.regex.RegexSplitter;
 import cascading.operation.text.DateFormatter;
+import cascading.pipe.CoGroup;
 import cascading.pipe.Pipe;
 import cascading.scheme.hadoop.TextLine;
 import cascading.tap.Tap;
@@ -215,10 +216,20 @@ public class TestPump extends TestCase {
     Pump right = Pump.prime("right")
         .each(new RegexSplitter(new Fields("date", "tag"),"\t"), "line");
 
-    Pipe nsp = left.cogroup(right, "date").toPipe();
-    Pipe stp = Pump.cogroup(left, right, "date").toPipe();
-    assertEquals(nsp.toString(), stp.toString());
-    assertTrue(Arrays.equals(nsp.getHeads(), stp.getHeads()));
+    CoGroup nonStaticPump = (CoGroup)left.cogroup(right, "date").toPipe();
+    CoGroup staticPump = (CoGroup)Pump.cogroup(left, right, "date").toPipe();
+    assertEquals(nonStaticPump.toString(), staticPump.toString());
+    
+    // NOTE: Since coGroup includes a rename internally, there is no way these two
+    // arrays will ever be equal, since Pipe's equal checks object identity. The
+    // left side is unmodified though, and can be checked for equality.
+    Pipe[] nonStaticHeads = nonStaticPump.getPrevious();
+    Pipe[] staticHeads = staticPump.getPrevious();
+    assertEquals(2, nonStaticHeads.length);
+    assertEquals(2, staticHeads.length);
+    assertEquals(nonStaticHeads[0], staticHeads[0]);
+    assertEquals(nonStaticHeads[1].toString(), staticHeads[1].toString()); 
+    
   }
   
   public void testUnique() throws Exception {


### PR DESCRIPTION
I took a real quick run at a non-static version of `cogroup` that should make the `Pump` API a little bit better. 
