### PR TITLE
Improve behavior of Pump.every with no arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.ch</groupId>
     <artifactId>cascading-helpers</artifactId>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.9-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading-helpers</name>

--- a/src/main/java/org/ch/pump/AggregatorPump.java
+++ b/src/main/java/org/ch/pump/AggregatorPump.java
@@ -3,6 +3,7 @@ package org.ch.pump;
 import cascading.operation.Aggregator;
 import cascading.pipe.Every;
 import cascading.pipe.Pipe;
+import cascading.tuple.Fields;
 
 public class AggregatorPump extends EveryPump {
   private final Aggregator agg;
@@ -13,6 +14,12 @@ public class AggregatorPump extends EveryPump {
   }
 
   @Override public Pipe getPipeInternal() {
-    return new Every(getPrev().toPipe(), getArgSelector(args), agg);
+    /*
+     * Use Fields.VALUES as the default field.
+     * This allows Pump#every and the aggregator to be called with no arguments while avoiding the
+     * name conflict that would happen if the aggregator uses the input arguments to name the output
+     * (as is done by First, for example).
+     */
+    return new Every(getPrev().toPipe(), getArgSelector(Fields.VALUES, args), agg);
   }
 }

--- a/src/main/java/org/ch/pump/Pump.java
+++ b/src/main/java/org/ch/pump/Pump.java
@@ -68,11 +68,14 @@ public abstract class Pump {
   }
 
   static Fields getArgSelector(String... args) {
-    Fields f = Fields.ALL;
+    return getArgSelector(Fields.ALL, args);
+  }
+
+  static Fields getArgSelector(Fields defaultFields, String... args) {
     if (args.length > 0) {
-      f = new Fields(args);
+      defaultFields = new Fields(args);
     }
-    return f;
+    return defaultFields;
   }
 
   public Pump each(Function function, String... args) {

--- a/src/test/java/org/ch/pump/TestPump.java
+++ b/src/test/java/org/ch/pump/TestPump.java
@@ -336,6 +336,36 @@ public class TestPump extends TestCase {
     assertEquals(Arrays.asList("key1\tvalue2"), outputStrings);
   }
 
+  /**
+   * Test calling Pump#every with no arguments.
+   * (Relies on AggregatorPump correctly setting the default arguments.)
+   */
+  public void testEvery() throws IOException {
+    String inputPath = "/tmp/TestPump/group_by_sec_sort";
+    FileSystem.get(new Configuration()).delete(new Path(inputPath), true);
+
+    Tap inTap = new Hfs(new SequenceFile(new Fields("key1", "key2")), inputPath);
+    TupleEntryCollector collector = inTap.openForWrite(new HadoopFlowProcess());
+    collector.add(new Tuple("key1", "value1"));
+    collector.add(new Tuple("key1", "value2"));
+    collector.close();
+
+    Pump pump = Pump.prime()
+        .retain("key1", "key2")
+        .groupby("key1")
+        .every(new First());
+    Pipe tail = pump.toPipe();
+
+    FlowDef flowDef = new FlowDef()
+        .addSource("input", inTap)
+        .addTail(tail)
+        .addSink(tail, new Hfs(new TextLine(new Fields("key1")), OUTPUT_PATH));
+
+    CascadingHelper.get().getFlowConnector().connect(flowDef).complete();
+    List<String> outputStrings = getOutputStrings();
+    assertEquals(Arrays.asList("key1\tvalue1"), outputStrings);
+  }
+
   public void testUnique() throws Exception {
     CascadingHelper.get().getFlowConnector().connect(getInTap(), getOutTap(), Pump.prime().retain("line").unique("line").toPipe()).complete();
     assertEquals(Arrays.asList("0", "115200000", "asdf"), getOutputStrings());


### PR DESCRIPTION
This allows Pump.every and the aggregator to be called with no arguments while avoiding the name conflict that would happen if the aggregator uses the input arguments to name the output (as is done by First, for example).
