### PR TITLE
Expose Cascading pseudo-combiners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.ch</groupId>
     <artifactId>cascading-helpers</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading-helpers</name>

--- a/src/main/java/org/ch/pump/AggregateByPump.java
+++ b/src/main/java/org/ch/pump/AggregateByPump.java
@@ -1,0 +1,45 @@
+package org.ch.pump;
+
+import cascading.operation.Aggregator;
+import cascading.pipe.Pipe;
+import cascading.pipe.assembly.AggregateBy;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AggregateByPump extends InternalPump {
+  private final AggregateBy aggregateBy;
+
+  public AggregateByPump(Pump prev, AggregateBy aggregateBy) {
+    super(prev);
+    this.aggregateBy = aggregateBy;
+  }
+
+  public AggregateByPump(Pump prev, AggregateBy.Functor functor, Aggregator aggregator,
+      String[] argumentFields) {
+    super(prev);
+    this.aggregateBy = new InternalAggregateBy(functor, aggregator, argumentFields);
+  }
+
+  @Override Pipe getPipeInternal() {
+    Pump cur = this;
+    List<AggregateBy> aggregators = new ArrayList<AggregateBy>();
+    while (true) {
+      if (cur instanceof AggregateByPump) {
+        aggregators.add(((AggregateByPump)cur).aggregateBy);
+        cur = cur.getPrev();
+      } else if (cur instanceof GroupByPump) {
+        return new AggregateBy(cur.getPrev().toPipe(), ((GroupByPump)cur).getFields(),
+            aggregators.toArray(new AggregateBy[aggregators.size()]));
+      } else {
+        throw new IllegalArgumentException(
+            "Partial aggregator must follow group by or other partial aggregator");
+      }
+    }
+  }
+
+  private static class InternalAggregateBy extends AggregateBy {
+    public InternalAggregateBy(Functor functor, Aggregator aggregator, String[] argumentFields) {
+      super(getArgSelector(argumentFields), functor, aggregator);
+    }
+  }
+}

--- a/src/main/java/org/ch/pump/GroupByPump.java
+++ b/src/main/java/org/ch/pump/GroupByPump.java
@@ -35,8 +35,12 @@ public class GroupByPump extends Pump {
     return this;
   }
 
+  public Fields getFields() {
+    return getArgSelector(fields);
+  }
+
   @Override Pump getPrev() {
-    throw new UnsupportedOperationException();
+    return this.prev;
   }
 
   @Override public Pipe getPipeInternal() {

--- a/src/main/java/org/ch/pump/Pump.java
+++ b/src/main/java/org/ch/pump/Pump.java
@@ -5,10 +5,15 @@ import cascading.operation.Buffer;
 import cascading.operation.Filter;
 import cascading.operation.Function;
 import cascading.pipe.Pipe;
+import cascading.pipe.assembly.AggregateBy;
+import cascading.pipe.assembly.AverageBy;
 import cascading.pipe.assembly.Coerce;
+import cascading.pipe.assembly.CountBy;
 import cascading.pipe.assembly.Discard;
+import cascading.pipe.assembly.FirstBy;
 import cascading.pipe.assembly.Rename;
 import cascading.pipe.assembly.Retain;
+import cascading.pipe.assembly.SumBy;
 import cascading.pipe.assembly.Unique;
 import cascading.pipe.joiner.InnerJoin;
 import cascading.pipe.joiner.Joiner;
@@ -91,7 +96,29 @@ public abstract class Pump {
     return new GroupByPump(this, fields);
   }
 
-  public Pump every(Aggregator agg, String... args) {
+  public Pump aggregateby(AggregateBy.Functor functor, Aggregator aggregator, String... args) {
+    return new AggregateByPump(this, functor, aggregator, args);
+  }
+
+  public Pump average(String valueField, String averageField) {
+    return new AggregateByPump(this,
+        new AverageBy(new Fields(valueField), new Fields(averageField)));
+  }
+
+  public Pump count(String countField) {
+    return new AggregateByPump(this, new CountBy(new Fields(countField)));
+  }
+
+  public Pump first(String... firstFields) {
+    return new AggregateByPump(this, new FirstBy(new Fields(firstFields)));
+  }
+
+  public Pump sum(String valueField, String sumField) {
+    return new AggregateByPump(this, new SumBy(new Fields(valueField), new Fields(sumField),
+        double.class));
+  }
+
+  public AggregatorPump every(Aggregator agg, String... args) {
     return new AggregatorPump(this, agg, args);
   }
 


### PR DESCRIPTION
Add an AggregateByPump that is initialized either with existing Cascading
partial aggregators (e.g. SumBy, CountBy, etc.) or with a custom Functor
(map-side aggregator) and Aggregator. These must come after a grouping operation
and can be combined with each other. An aggregate by operation cannot be
combined with an every operation.
