### PR TITLE
Allow custom prefix for cogroup field names on RHS

### DIFF
--- a/src/main/java/org/ch/pump/Pump.java
+++ b/src/main/java/org/ch/pump/Pump.java
@@ -61,6 +61,10 @@ public abstract class Pump {
   }
 
   public static CoGroupPump cogroup(Pump left, Pump right, Joiner joiner, String... cogroupFields) {
+    return cogroup(left,  "__rhs__", right, joiner, cogroupFields);
+  }
+
+  public static CoGroupPump cogroup(Pump left,  String prefix, Pump right, Joiner joiner, String... cogroupFields) {
     String[] modifiedCogroupFields = new String[cogroupFields.length];
     for (int i = 0; i < cogroupFields.length; i++) {
       String cogroupField = cogroupFields[i];


### PR DESCRIPTION
When there are multiple cogroups in a pipeline the prefix '**rhs**' can collide if the fields have a common name. This allows us to specify a custom prefix.

eg.

``` java
Pump.cogroup(tableA, users, "user_id")
    .cogroup(tableB, new LeftJoin(), "user_id");
```

will conflict, but can instead be

``` java
Pump.cogroup(tableA, "users_", users, "user_id")
    .cogroup(tableB, "tableB_", new LeftJoin(), "user_id");
```
