### PR TITLE
Pump and CascadingHelper support for dynamically detecting serialization tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.ch</groupId>
     <artifactId>cascading-helpers</artifactId>
-    <version>0.12-SNAPSHOT</version>
+    <version>0.13-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>cascading-helpers</name>

--- a/src/main/java/org/ch/CascadingHelper.java
+++ b/src/main/java/org/ch/CascadingHelper.java
@@ -107,4 +107,8 @@ public class CascadingHelper {
     }
     return THE_HELPER;
   }
+
+  public CascadingHelper withTokensFor(Set<Class> emittedClasses) {
+    return withTokensFor(emittedClasses.toArray(new Class[emittedClasses.size()]));
+  }
 }

--- a/src/main/java/org/ch/CascadingHelper.java
+++ b/src/main/java/org/ch/CascadingHelper.java
@@ -3,12 +3,9 @@ package org.ch;
 import cascading.flow.FlowConnector;
 import cascading.flow.hadoop.HadoopFlowConnector;
 import cascading.tuple.hadoop.TupleSerialization;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
+
 import org.apache.hadoop.io.serializer.Serialization;
 import org.apache.hadoop.io.serializer.WritableSerialization;
 import org.apache.hadoop.mapred.JobConf;
@@ -102,5 +99,12 @@ public class CascadingHelper {
 
   public FlowConnector getFlowConnector(Map<Object, Object> properties) {
     return new HadoopFlowConnector(mergeProperties(properties));
+  }
+
+  public CascadingHelper withTokensFor(Class... emittedClasses) {
+    for (Class klass : emittedClasses) {
+      CLASSES_TO_BE_SERIALIZED.add(klass);
+    }
+    return THE_HELPER;
   }
 }

--- a/src/main/java/org/ch/operation/KnowsEmittedClasses.java
+++ b/src/main/java/org/ch/operation/KnowsEmittedClasses.java
@@ -1,0 +1,11 @@
+package org.ch.operation;
+
+import cascading.operation.Function;
+import java.util.Set;
+
+/**
+ * Does your Function know which classes it can emit? Tell us so we can analyze!
+ */
+public interface KnowsEmittedClasses extends Function {
+  public Set<Class> getEmittedClasses();
+}

--- a/src/main/java/org/ch/pump/CoGroupPump.java
+++ b/src/main/java/org/ch/pump/CoGroupPump.java
@@ -3,6 +3,8 @@ package org.ch.pump;
 import cascading.pipe.CoGroup;
 import cascading.pipe.Pipe;
 import cascading.pipe.joiner.Joiner;
+import java.util.HashSet;
+import java.util.Set;
 
 public class CoGroupPump extends Pump {
   private final Pump left;
@@ -10,6 +12,15 @@ public class CoGroupPump extends Pump {
   private final Pump right;
   private final String[] modifiedCogroupFields;
   private final Joiner joiner;
+
+  @Override public Set<Class> getEmittedClasses() {
+    Set<Class> leftClasses = left.getEmittedClasses();
+    Set<Class> rightClasses = right.getEmittedClasses();
+    Set<Class> combined = new HashSet<Class>();
+    combined.addAll(leftClasses);
+    combined.addAll(rightClasses);
+    return combined;
+  }
 
   CoGroupPump(Pump left, String[] cogroupFields, Pump right, String[] modifiedCogroupFields,
       Joiner joiner) {

--- a/src/main/java/org/ch/pump/FunctionPump.java
+++ b/src/main/java/org/ch/pump/FunctionPump.java
@@ -4,7 +4,10 @@ import cascading.operation.Function;
 import cascading.pipe.Each;
 import cascading.pipe.Pipe;
 import cascading.tuple.Fields;
+import java.util.HashSet;
+import java.util.Set;
 import org.ch.function.StacktraceWrapperFunction;
+import org.ch.operation.KnowsEmittedClasses;
 
 public class FunctionPump extends InternalPump {
   private Function function;
@@ -18,5 +21,16 @@ public class FunctionPump extends InternalPump {
 
   @Override public Pipe getPipeInternal() {
     return new Each(getPrev().toPipe(), getArgSelector(args), new StacktraceWrapperFunction(function, getStackTrace()), Fields.ALL);
+  }
+
+  @Override public Set<Class> getEmittedClasses() {
+    Set<Class> combined = new HashSet<Class>();
+
+    if (function instanceof KnowsEmittedClasses) {
+      Set<Class> emittedClasses = ((KnowsEmittedClasses)function).getEmittedClasses();
+      combined.addAll(emittedClasses);
+    }
+    combined.addAll(super.getEmittedClasses());
+    return combined;
   }
 }

--- a/src/main/java/org/ch/pump/Pump.java
+++ b/src/main/java/org/ch/pump/Pump.java
@@ -20,6 +20,8 @@ import cascading.pipe.joiner.Joiner;
 import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 import org.ch.function.GetOrElse;
 
@@ -28,6 +30,15 @@ public abstract class Pump {
 
   abstract Pump getPrev();
   abstract Pipe getPipeInternal();
+
+  public Set<Class> getEmittedClasses() {
+    Set<Class> upstreamClasses = Collections.EMPTY_SET;
+    if (getPrev() != null) {
+      upstreamClasses = getPrev().getEmittedClasses();
+    }
+
+    return upstreamClasses;
+  }
 
   public final Pipe toPipe() {
     if (memoizedPipe == null) {

--- a/src/test/java/org/ch/CascadingHelperTest.java
+++ b/src/test/java/org/ch/CascadingHelperTest.java
@@ -1,0 +1,27 @@
+package org.ch;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static junit.framework.Assert.assertTrue;
+
+public class CascadingHelperTest {
+  private static final class X {}
+  private static final class Y {}
+  private static final class Z {}
+
+  @Test
+  public void testWithTokensFor() throws Exception {
+    Map<Object,Object> properties = CascadingHelper.get().withTokensFor(X.class, Y.class).getFlowConnector().getProperties();
+    String tokensString = (String) properties.get("cascading.serialization.tokens");
+    assertTrue(tokensString.contains(X.class.getName()));
+    assertTrue(tokensString.contains(Y.class.getName()));
+
+    properties = CascadingHelper.get().withTokensFor(X.class, Y.class, Z.class).getFlowConnector().getProperties();
+    tokensString = (String) properties.get("cascading.serialization.tokens");
+    assertTrue(tokensString.contains(X.class.getName()));
+    assertTrue(tokensString.contains(Y.class.getName()));
+    assertTrue(tokensString.contains(Z.class.getName()));
+  }
+}

--- a/src/test/java/org/ch/pump/TestPump.java
+++ b/src/test/java/org/ch/pump/TestPump.java
@@ -49,7 +49,6 @@ import org.ch.CascadingHelper;
 import org.ch.operation.KnowsEmittedClasses;
 
 public class TestPump extends TestCase {
-
   private static final String INPUT_PATH = "/tmp/TestPump/input";
   private static final String INPUT2_PATH = "/tmp/TestPump/input2";
   private static final String OUTPUT_PATH = "/tmp/TestPump/output";
@@ -259,7 +258,7 @@ public class TestPump extends TestCase {
   }
 
   public void testCoGroupEquality() {
-	  Pump left = Pump.prime("left")
+	Pump left = Pump.prime("left")
         .each(new RegexFilter("^[0-9]+$", false), "line")
         .retain("line")
         .coerce("line", int.class)
@@ -488,7 +487,6 @@ public class TestPump extends TestCase {
   private static class Right {}
 
   private class FunctionThatKnows extends BaseOperation implements KnowsEmittedClasses {
-
     private final Class klass;
 
     public FunctionThatKnows(Class klass) {
@@ -510,31 +508,31 @@ public class TestPump extends TestCase {
     }
     return results;
   }
-  private static class BufferFirst extends BaseOperation implements Buffer {
 
+  private static class BufferFirst extends BaseOperation implements Buffer {
     private BufferFirst() {
       super(new Fields("date2"));
     }
+
     @Override public void operate(FlowProcess flowProcess, BufferCall bufferCall) {
       Iterator<TupleEntry> argumentsIterator = bufferCall.getArgumentsIterator();
       bufferCall.getOutputCollector().add(argumentsIterator.next().getTuple());
     }
-
   }
+
   private static class FailingFunction extends BaseOperation implements Function {
     @Override public void operate(FlowProcess flowProcess, FunctionCall functionCall) {
       throw new RuntimeException("intentional failure kthxbye");
     }
-
   }
+
   private static class FailingFilter extends BaseOperation implements Filter {
     @Override public boolean isRemove(FlowProcess flowProcess, FilterCall filterCall) {
       throw new RuntimeException("intentional failure kthxbye");
     }
-
   }
-  private static class MaxFunctor implements AggregateBy.Functor {
 
+  private static class MaxFunctor implements AggregateBy.Functor {
     @Override public Fields getDeclaredFields() {
       return new Fields("max");
     }
@@ -548,9 +546,9 @@ public class TestPump extends TestCase {
       }
       return context;
     }
+
     @Override public Tuple complete(FlowProcess flowProcess, Tuple context) {
       return context;
     }
-
   }
 }


### PR DESCRIPTION
This adds a new interface for Functions and Filters to implement that allows them to return a list of known emitted classes. Pump then provides a method for traversing the pre-assembly pipe graph to collect all emitted classes. The results can be passed to a new method on CascadingHelper, withTokensFor, which will assign tokens appropriately.
