### PR TITLE
starts out FlowBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.ipr
 *.iws
 target
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>com.squareup</groupId>
     <artifactId>cascading-helpers</artifactId>
-    <version>0.15</version>
+    <version>0.16</version>
     <packaging>jar</packaging>
 
     <name>cascading-helpers</name>

--- a/src/main/java/com/squareup/cascading_helpers/CascadingHelper.java
+++ b/src/main/java/com/squareup/cascading_helpers/CascadingHelper.java
@@ -41,10 +41,19 @@ public class CascadingHelper {
 
   private static final CascadingHelper THE_HELPER = new CascadingHelper();
 
+  /**
+   * @deprecated use {@link #newBuilder()} instead.
+   * @return the singleton instance of the helper.
+   */
+  @Deprecated
   public static CascadingHelper get() {
     return THE_HELPER;
   }
 
+  /**
+   * See {@link com.squareup.cascading_helpers.FlowBuilder}.
+   * @return {@link com.squareup.cascading_helpers.FlowBuilder}
+   */
   public static FlowBuilder newBuilder() {
     return new FlowBuilder();
   }

--- a/src/main/java/com/squareup/cascading_helpers/CascadingHelper.java
+++ b/src/main/java/com/squareup/cascading_helpers/CascadingHelper.java
@@ -29,6 +29,7 @@ public class CascadingHelper {
   private static boolean testMode = false;
 
   protected static final Map<Object, Object> DEFAULT_PROPERTIES = new HashMap<Object, Object>();
+  @SuppressWarnings({"unchecked"})
   protected static final List<Class<? extends Serialization>> SERIALIZATION_IMPLS =
       new ArrayList<Class<? extends Serialization>>(Arrays.asList(
               WritableSerialization.class,
@@ -42,6 +43,10 @@ public class CascadingHelper {
 
   public static CascadingHelper get() {
     return THE_HELPER;
+  }
+
+  public static FlowBuilder newBuilder() {
+    return new FlowBuilder();
   }
 
   /**
@@ -80,8 +85,8 @@ public class CascadingHelper {
   private static void addSerializations(Map<Object, Object> props) {
     JobConf jobConf = new JobConf();
     String existingSerializations = jobConf.get(IO_SERIALIZATIONS);
-    ArrayList<String> serializations =
-        new ArrayList(Arrays.asList(existingSerializations.split(",")));
+    List<String> serializations =
+        new ArrayList<String>(Arrays.asList(existingSerializations.split(",")));
     for (Class<? extends Serialization> serClass : SERIALIZATION_IMPLS) {
       serializations.add(serClass.getName());
     }
@@ -109,9 +114,7 @@ public class CascadingHelper {
   }
 
   public CascadingHelper withTokensFor(Class... emittedClasses) {
-    for (Class klass : emittedClasses) {
-      CLASSES_TO_BE_SERIALIZED.add(klass);
-    }
+    Collections.addAll(CLASSES_TO_BE_SERIALIZED, emittedClasses);
     return THE_HELPER;
   }
 

--- a/src/main/java/com/squareup/cascading_helpers/FlowBuilder.java
+++ b/src/main/java/com/squareup/cascading_helpers/FlowBuilder.java
@@ -18,6 +18,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * FlowBuilder is a fluent interface extending FlowDef to better integrate with
+ * the {@link com.squareup.cascading_helpers.operation.KnowsEmittedClasses} interface. It is meant
+ * to assist in declaratively building a FlowDef, and returns the {@link cascading.flow.Flow} upon
+ * calling the {@link #build()} method.
+ */
 public class FlowBuilder {
   private final FlowDef flowDef;
   private final Set<Class> emittedClasses;
@@ -76,16 +82,34 @@ public class FlowBuilder {
     return this;
   }
 
+  /**
+   * List of {@link cascading.flow.FlowListener} to be attached to the {@link cascading.flow.Flow}.
+   * @param listeners - {@link java.util.List} of {@link cascading.flow.FlowListener}s.
+   * @return {@link com.squareup.cascading_helpers.FlowBuilder}.
+   */
   public FlowBuilder listeners(List<FlowListener> listeners) {
     this.listeners.addAll(listeners);
     return this;
   }
 
+  /**
+   * Map of underlying properties applied to the {@link cascading.flow.FlowConnector} for the
+   * cascading job being build.
+   * @param properties - {@link java.util.Map} of properties for the underlying
+   * {@link cascading.flow.hadoop.HadoopFlowConnector}
+   * @return {@link com.squareup.cascading_helpers.FlowBuilder}.
+   */
   public FlowBuilder properties(Map<Object, Object> properties) {
     this.properties.putAll(properties);
     return this;
   }
 
+  /**
+   * Builds the underlying {@link cascading.flow.FlowDef} by populating the emittedClasses that
+   * each tail sink knows of, attaching any provided {@link #properties(java.util.Map)} and
+   * {@link #listeners(java.util.List)}, and returning the {@link cascading.flow.Flow}.
+   * @return {@link cascading.flow.Flow}.
+   */
   public Flow build() {
     CascadingHelper helper = CascadingHelper.get().withTokensFor(emittedClasses);
     FlowConnector connector;
@@ -102,5 +126,17 @@ public class FlowBuilder {
       }
     }
     return flow;
+  }
+
+  /**
+   * Get a handle to the current {@link #flowDef}. Use discouraged.
+   * @return
+   */
+  public FlowDef getFlowDef() {
+    return this.flowDef;
+  }
+
+  public Set<Class> getEmittedClasses() {
+    return emittedClasses;
   }
 }

--- a/src/main/java/com/squareup/cascading_helpers/FlowBuilder.java
+++ b/src/main/java/com/squareup/cascading_helpers/FlowBuilder.java
@@ -1,0 +1,106 @@
+package com.squareup.cascading_helpers;
+
+import cascading.flow.Flow;
+import cascading.flow.FlowConnector;
+import cascading.flow.FlowDef;
+import cascading.flow.FlowListener;
+import cascading.scheme.hadoop.TextLine;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.Hfs;
+import com.squareup.cascading_helpers.pump.Pump;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FlowBuilder {
+  private final FlowDef flowDef;
+  private final Set<Class> emittedClasses;
+  private final List<FlowListener> listeners;
+  private final Map<Object, Object> properties;
+
+  protected FlowBuilder() {
+    this.flowDef = new FlowDef();
+    this.emittedClasses = new HashSet<Class>();
+    this.listeners = new ArrayList<FlowListener>();
+    this.properties = new HashMap<Object, Object>();
+  }
+
+  public FlowBuilder hfsTextLineTailSink(Pump pump, String path, SinkMode mode) {
+    emittedClasses.addAll(pump.getEmittedClasses());
+    tailSink(pump, new Hfs(new TextLine(), path, mode));
+    return this;
+  }
+
+  public FlowBuilder tailSink(Pump pump, Tap tap) {
+    emittedClasses.addAll(pump.getEmittedClasses());
+    flowDef.addTailSink(pump.toPipe(), tap);
+    return this;
+  }
+
+  public FlowBuilder sink(Pump pump, Tap tap) {
+    emittedClasses.addAll(pump.getEmittedClasses());
+    flowDef.addSink(pump.toPipe(), tap);
+    return this;
+  }
+
+  public FlowBuilder source(String name, Tap tap) {
+    Pump pump = Pump.prime(name);
+    flowDef.addSource(pump.toPipe(), tap);
+    return this;
+  }
+
+  public FlowBuilder source(Pump pump, Tap tap) {
+    flowDef.addSource(pump.toPipe(), tap);
+    return this;
+  }
+
+  public FlowBuilder sources(Map<String, Tap> sources) {
+    flowDef.addSources(sources);
+    return this;
+  }
+
+  public FlowBuilder trap(Pump pump, Tap trap) {
+    emittedClasses.addAll(pump.getEmittedClasses());
+    flowDef.addTrap(pump.toPipe(), trap);
+    return this;
+  }
+
+  public FlowBuilder name(String name) {
+    flowDef.setName(name);
+    return this;
+  }
+
+  public FlowBuilder listeners(List<FlowListener> listeners) {
+    this.listeners.addAll(listeners);
+    return this;
+  }
+
+  public FlowBuilder properties(Map<Object, Object> properties) {
+    this.properties.putAll(properties);
+    return this;
+  }
+
+  public Flow build() {
+    CascadingHelper helper = CascadingHelper.get().withTokensFor(emittedClasses);
+    FlowConnector connector;
+    if (!properties.isEmpty()) {
+      connector = helper.getFlowConnector(properties);
+    } else {
+      connector = helper.getFlowConnector();
+    }
+
+    Flow flow = connector.connect(flowDef);
+    if (!listeners.isEmpty()) {
+      for (FlowListener l : listeners) {
+        flow.addListener(l);
+      }
+    }
+    return flow;
+  }
+}

--- a/src/main/java/com/squareup/cascading_helpers/pump/PipeAdapterPump.java
+++ b/src/main/java/com/squareup/cascading_helpers/pump/PipeAdapterPump.java
@@ -4,6 +4,7 @@ import cascading.pipe.Pipe;
 
 public class PipeAdapterPump extends Pump {
   private Pipe pipe;
+  private Pump prev;
 
   public PipeAdapterPump(String name) {
     this(new Pipe(name));
@@ -13,8 +14,13 @@ public class PipeAdapterPump extends Pump {
     this.pipe = pipe;
   }
 
+  public PipeAdapterPump(Pump prev, Pipe pipe) {
+    this.prev = prev;
+    this.pipe = pipe;
+  }
+
   @Override Pump getPrev() {
-    return null;
+    return prev;
   }
 
   @Override public Pipe getPipeInternal() {

--- a/src/main/java/com/squareup/cascading_helpers/pump/Pump.java
+++ b/src/main/java/com/squareup/cascading_helpers/pump/Pump.java
@@ -34,7 +34,7 @@ public abstract class Pump {
   abstract Pipe getPipeInternal();
 
   public Set<Class> getEmittedClasses() {
-    Set<Class> upstreamClasses = Collections.EMPTY_SET;
+    Set<Class> upstreamClasses = Collections.emptySet();
     if (getPrev() != null) {
       upstreamClasses = getPrev().getEmittedClasses();
     }
@@ -109,7 +109,7 @@ public abstract class Pump {
   }
 
   public Pump unique(String... uniqueFields) {
-    return new PipeAdapterPump(new Unique(toPipe(), getArgSelector(uniqueFields)));
+    return new PipeAdapterPump(this, new Unique(toPipe(), getArgSelector(uniqueFields)));
   }
 
   public GroupByPump groupby(String... fields) {
@@ -147,11 +147,11 @@ public abstract class Pump {
   }
 
   public Pump retain(String ... fieldsToKeep) {
-    return new PipeAdapterPump(new Retain(toPipe(), getArgSelector(fieldsToKeep)));
+    return new PipeAdapterPump(this, new Retain(toPipe(), getArgSelector(fieldsToKeep)));
   }
 
   public Pump discard(String ... fieldsToDiscard) {
-    return new PipeAdapterPump(new Discard(toPipe(), getArgSelector(fieldsToDiscard)));
+    return new PipeAdapterPump(this, new Discard(toPipe(), getArgSelector(fieldsToDiscard)));
   }
 
   public Pump coerce(String field, Class toClass) {
@@ -165,11 +165,11 @@ public abstract class Pump {
   }
 
   public Pump coerce(String[] fields, Class<?>[] classes) {
-    return new PipeAdapterPump(new Coerce(toPipe(), new Fields(fields), classes));
+    return new PipeAdapterPump(this, new Coerce(toPipe(), new Fields(fields), classes));
   }
 
   public Pump rename(String field, String toName) {
-    return new PipeAdapterPump(new Rename(toPipe(), new Fields(field), new Fields(toName)));
+    return new PipeAdapterPump(this, new Rename(toPipe(), new Fields(field), new Fields(toName)));
   }
 
   public Pump replace(String field, String toName) {

--- a/src/test/java/com/squareup/cascading_helpers/FlowBuilderTest.java
+++ b/src/test/java/com/squareup/cascading_helpers/FlowBuilderTest.java
@@ -1,0 +1,78 @@
+package com.squareup.cascading_helpers;
+
+import cascading.flow.Flow;
+import cascading.flow.FlowListener;
+import com.squareup.cascading_helpers.pump.Pump;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class FlowBuilderTest {
+  @Before
+  public void setUp() throws Exception {
+    CascadingHelper.setTestMode();
+    FileSystem.get(new Configuration()).delete(new Path(Tests.INPUT_PATH), true);
+    FileSystem.get(new Configuration()).delete(new Path(Tests.TRAP_PATH), true);
+    FileSystem.get(new Configuration()).delete(new Path(Tests.OUTPUT_PATH), true);
+    Tests.fillTap(Tests.INPUT_TUPLES, Tests.getTap(Tests.INPUT_PATH));
+  }
+
+  @Test
+  public void happyPath() throws Exception {
+    Pump p = Pump.prime("input")
+        .each(new Tests.FunctionThatKnows(Tests.Left.class))
+        .retain("line");
+
+    TestListener listener = new TestListener();
+    String name = "testing FlowBuilder";
+    HashMap<Object, Object> properties = new HashMap<Object, Object>();
+    properties.put("some hadoop stuff", "as this thing");
+
+    FlowBuilder builder = new FlowBuilder().name(name)
+        .source(p, Tests.getInTap())
+        .trap(p, Tests.getOutTap())
+        .tailSink(p, Tests.getTrap())
+        .listeners(Arrays.<FlowListener>asList(listener))
+        .properties(properties);
+
+    assertThat(builder.getEmittedClasses(), hasItem(Tests.Left.class));
+
+    Flow flow = builder.build();
+    flow.complete();
+
+    assertNotNull(flow.getSource("input"));
+    assertFalse(flow.getTraps().isEmpty());
+    assertThat(flow.getName(), equalTo(name));
+    assertFalse(flow.getSinks().isEmpty());
+
+    assertTrue(listener.completed);
+  }
+
+  private static class TestListener implements FlowListener {
+    public boolean completed = false;
+
+    @Override public void onStarting(Flow flow) {
+    }
+
+    @Override public void onStopping(Flow flow) {
+    }
+
+    @Override public void onCompleted(Flow flow) {
+      this.completed = true;
+    }
+
+    @Override public boolean onThrowable(Flow flow, Throwable throwable) {
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/squareup/cascading_helpers/Tests.java
+++ b/src/test/java/com/squareup/cascading_helpers/Tests.java
@@ -1,0 +1,74 @@
+package com.squareup.cascading_helpers;
+
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop.HadoopFlowProcess;
+import cascading.operation.BaseOperation;
+import cascading.operation.FunctionCall;
+import cascading.scheme.hadoop.TextLine;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.Hfs;
+import cascading.tuple.Fields;
+import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntry;
+import cascading.tuple.TupleEntryCollector;
+import com.squareup.cascading_helpers.operation.KnowsEmittedClasses;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class Tests {
+  public static final String INPUT_PATH = "/tmp/TestPump/input";
+  public static final String TRAP_PATH = "/tmp/TestPump/trap";
+  public static final String OUTPUT_PATH = "/tmp/TestPump/output";
+  public static final List<Tuple> INPUT_TUPLES = new ArrayList<Tuple>(){{
+    add(new Tuple("115200000"));
+    add(new Tuple("0"));
+    add(new Tuple("115200000"));
+    add(new Tuple("asdf"));
+  }};
+
+  @SuppressWarnings({"unchecked"})
+  public static void fillTap(List<Tuple> tuples, Tap tap) throws IOException {
+    TupleEntryCollector tec = tap.openForWrite(new HadoopFlowProcess());
+    for (Tuple t : tuples) {
+      tec.add(new TupleEntry(new Fields("line"), t));
+    }
+    tec.close();
+  }
+
+  public static Tap getTap(String path) {
+    return new Hfs(new TextLine(), path);
+  }
+
+  public static Tap getInTap() {
+    return getTap(INPUT_PATH);
+  }
+
+  public static Tap getOutTap() {
+    return getTap(OUTPUT_PATH);
+  }
+
+  public static Tap getTrap() {
+    return getTap(TRAP_PATH);
+  }
+
+  public static class Left {}
+
+  public static class Right {}
+
+  public static class FunctionThatKnows extends BaseOperation implements KnowsEmittedClasses {
+    private final Class klass;
+
+    public FunctionThatKnows(Class klass) {
+      this.klass = klass;
+    }
+
+    @Override public Set<Class> getEmittedClasses() {
+      return Collections.singleton(klass);
+    }
+    @Override public void operate(FlowProcess flowProcess, FunctionCall functionCall) {
+    }
+  }
+}


### PR DESCRIPTION
**do not merge**

@bryanduxbury could use some ideas for testing. current thoughts: add to the existing PumpTest. Making a separate test file is duplicates a lot from there for a simple delegating-builder.

also, any thoughts on dropping/deprecating the static get() method in favor of always using the new FlowBuilder interface?
